### PR TITLE
Using the `deb12cis_sudo_package` in the implementation of control 5.2.1

### DIFF
--- a/tasks/section_5/cis_5.2.x.yml
+++ b/tasks/section_5/cis_5.2.x.yml
@@ -10,7 +10,7 @@
     - rule_5.2.1
     - NIST800-53R5_AC-6
   ansible.builtin.package:
-    name: sudo
+    name: "{{ deb12cis_sudo_package }}"
     state: present
 
 - name: "5.2.2 | PATCH | Ensure sudo commands use pty"


### PR DESCRIPTION
**Overall Review of Changes:**
This PR fixes this [issue](https://github.com/ansible-lockdown/DEBIAN12-CIS/issues/34)

**Issue Fixes:**

- https://github.com/ansible-lockdown/DEBIAN12-CIS/issues/34

**Enhancements:**
None

**How has this been tested?:**
N/A

