### PR TITLE
also remove inetutils-telnet with telnet (solves #49)

### DIFF
--- a/tasks/section_2/cis_2.2.x.yml
+++ b/tasks/section_2/cis_2.2.x.yml
@@ -55,7 +55,9 @@
     - rule_2.2.4
     - telnet
   ansible.builtin.package:
-    name: telnet
+    name:
+      - telnet
+      - inetutils-telnet
     state: absent
     purge: "{{ deb12cis_purge_apt }}"
 


### PR DESCRIPTION
**Overall Review of Changes:**
Removes inetutils-telnet along with telnet so that the telnet-client is indeed removed

**Issue Fixes:**
#49 

**How has this been tested?:**
Since there are no tests, this has just been A/B tested on a Debian 12 server
