### PR TITLE
fix for #52: adds default for deb12cis_ipv4_required

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -707,6 +707,7 @@ deb12cis_bluetooth_mask: false
 
 ## 3.1 IPv6 requirement toggle
 # This variable governs whether ipv6 is enabled or disabled.
+deb12cis_ipv4_required: true
 deb12cis_ipv6_required: true
 
 ## 3.1.2 wireless network requirements


### PR DESCRIPTION
**Overall Review of Changes:**
adds default `true` for `deb12cis_ipv4_required`

**Issue Fixes:**
#52 

**Enhancements:**
-

**How has this been tested?:**
Ran against a Debian 12 server

