### PR TITLE
fix(cis_6.3.4.3): change audit log group owner from root to adm

### DIFF
--- a/tasks/section_6/cis_6.3.4.x.yml
+++ b/tasks/section_6/cis_6.3.4.x.yml
@@ -21,7 +21,7 @@
     path: "{{ prelim_auditd_logfile.stdout }}"
     mode: 'o-x,g-wx,o-rwx'
     owner: root
-    group: root
+    group: adm
 
 - name: "6.3.4.4 | PATCH | Ensure the audit log file directory mode is configured"
   when: deb12cis_rule_6_3_4_4


### PR DESCRIPTION
**Overall Review of Changes:**
This fix addresses the issues outlined in the linked issue below. Namely, it sets the group owner of the audit log files to `adm` to match the default `auditd.conf` on Debian as opposed to `root`.

**Issue Fixes:**
Closes #59 

**How has this been tested?:**
Have run with this change has it comes back as not-changed when using the Debian default `log_group` of `adm` as expected.

```bash
TASK [ansible-lockdown.deb12_cis : "6.3.4.1 | PATCH | Ensure audit log files mode is configured"
"6.3.4.2 | PATCH | Ensure only authorized users own audit log files"
"6.3.4.3 | PATCH | Ensure only authorized groups are assigned ownership of audit log files"] ***
task path: /home/arcticdolphin/.ansible/roles/ansible-lockdown.deb12_cis/tasks/section_6/cis_6.3.4.x.yml:3
ok: [nld01git01.prd.cray.sh] => {"changed": false, "gid": 4, "group": "adm", "mode": "0640", "owner": "root", "path": "/var/log/audit/audit.log", "size": 2829492, "state": "file", "uid": 0}
```