### PR TITLE
root password check can have a non-zero rc

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,6 +100,7 @@
     - name: "Ensure root password is set"
       ansible.builtin.shell: passwd -S root | grep 'root P'
       changed_when: false
+      failed_when: false
       register: prelim_check_root_passwd_set
 
     - name: "Ensure root password is set"


### PR DESCRIPTION
`grep` returns non-zero if the string is not found, thus failing the command. The playbook will fail itself on line 106, so the non-zero return code of grep should be ignored.