### PR TITLE
execute non-destructive commands in check mode

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -35,6 +35,7 @@
   ansible.builtin.shell: >
     grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false" && $7 != "/dev/null") { print $1 }'
   changed_when: false
+  check_mode: false
   register: prelim_interactive_usernames
 
 - name: "PRELIM | AUDIT | Interactive User accounts home directories"
@@ -43,6 +44,7 @@
   ansible.builtin.shell: >
     grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $6 }'
   changed_when: false
+  check_mode: false
   register: prelim_interactive_users_home
 
 - name: "PRELIM | AUDIT | Interactive UIDs"
@@ -51,6 +53,7 @@
   ansible.builtin.shell: >
     grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '(!index($7, "sbin/nologin") && $7 != "/bin/nologin" && $7 != "/bin/false") { print $3 }'
   changed_when: false
+  check_mode: false
   register: prelim_interactive_uids
 
 - name: "PRELIM | AUDIT | Capture /etc/password variables"
@@ -78,6 +81,7 @@
       ansible.builtin.shell: |
         mount | awk '{print $1, $3, $5, $6}'
       changed_when: false
+      check_mode: false
       register: prelim_mount_output
 
     - name: PRELIM | AUDIT | Section 1.1 | Retrieve mount options - build fact  # This is inherited and used in mountpoints tasks
@@ -131,6 +135,7 @@
       ansible.builtin.shell: find /sys/class/net/*/ -type d -name wireless
       register: prelim_wireless_adapters
       changed_when: false
+      check_mode: false
       failed_when: prelim_wireless_adapters.rc not in [ 0, 1 ]
 
     - name: "PRELIM | AUDIT | If wireless adapter present capture module"
@@ -141,6 +146,7 @@
           do basename "$(readlink -f "$driverdir"/device/driver/module)";
         done | sort -u
       changed_when: false
+      check_mode: false
       failed_when: prelim_wireless_modules.rc not in [ 0, 1 ]
       register: prelim_wireless_modules
 
@@ -182,7 +188,7 @@
     modification_time: preserve
     access_time: preserve
   register: prelim_pwquality_dummy
-  changed_when: prelim_pwquality_dummy.diff == "absent"
+  changed_when: prelim_pwquality_dummy.diff is defined and prelim_pwquality_dummy.diff == "absent"
   loop:
     - { path: '/etc/security/pwquality.conf.d', state: 'directory' }
     - { path: '/etc/security/pwquality.conf.d/cis_dummy.conf', state: 'touch' }
@@ -243,6 +249,7 @@
   tags: always
   ansible.builtin.shell: grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'
   changed_when: false
+  check_mode: false
   register: prelim_auditd_logfile
 
 - name: "PRELIM | AUDIT | Audit conf and rules files | list files"
@@ -272,11 +279,13 @@
     - name: "PRELIM | AUDIT | Capture UID_MIN information from logins.def"
       ansible.builtin.shell: grep -w "^UID_MIN" /etc/login.defs | awk '{print $NF}'
       changed_when: false
+      check_mode: false
       register: prelim_uid_min_id
 
     - name: "PRELIM | AUDIT | Capture UID_MAX information from logins.def"
       ansible.builtin.shell: grep -w "^UID_MAX" /etc/login.defs | awk '{print $NF}'
       changed_when: false
+      check_mode: false
       register: prelim_uid_max_id
 
     - name: "PRELIM | AUDIT | Set facts for interactive uid/gid"
@@ -304,6 +313,7 @@
       changed_when: false
       failed_when: false
       ignore_errors: true
+      check_mode: false
       register: discovered_uas_status
 
     - name: "Optional | PATCH | Remove UAS kernel module if running and not allowed"


### PR DESCRIPTION
Various (non-destructive) tasks were not being executed in check_mode on deb12cis playbook.