### PR TITLE
Allow exclusion of mountpoints for the filesearch in 6.3.3.6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1354,6 +1354,12 @@ deb12cis_auditd_uid_exclude:
 deb12cis_auditd_extra_conf:
   admin_space_left: '10%'
 
+# 6.3.3.6 exclude listed mountpoints from the find command to locate privileged binaries
+# Allows operator to exclude mounted devices from being considered as within scope to find privileged binaries; mainly in the case of
+# external/temporary mounted USB drives.
+#   deb12cis_priv_command_excluded_mounts: ["/mnt/backup_disk", "/mnt/usb_external_storage"]
+deb12cis_priv_command_excluded_mounts: []
+
 # Section 7 Vars
 
 # 7.1.12 Ensure no files or directories without an owner and a group exist

--- a/tasks/section_6/cis_6.2.3.x.yml
+++ b/tasks/section_6/cis_6.2.3.x.yml
@@ -77,8 +77,12 @@
     - rule_6.2.3.6
     - NIST800-53R5_AU-3
   block:
-    - name: "6.2.3.6 | PATCH | Ensure use of privileged commands is collected"
-      ansible.builtin.shell: for i in  $(df | grep '^/dev' | awk '{ print $NF }'); do find $i -xdev -type f -perm /6000 2>/dev/null; done
+    - name: "6.3.3.6 | PATCH | Ensure use of privileged commands is collected"
+      ansible.builtin.shell: |
+        {%- set egrep_exclude = "(asdfmnop|{{ deb12cis_priv_command_excluded_mounts | join('|') }})" -%}
+        for i in $(df | grep '^/dev' | grep -Ev '{{ egrep_exclude }}' | awk '{ print $NF }'); do
+          find $i -xdev -type f -perm /6000 2>/dev/null;
+        done
       changed_when: false
       failed_when: false
       check_mode: false


### PR DESCRIPTION
Allow exclusion of mountpoints for the filesearch in 6.3.3.6 

Updated the default/var.yml to give default blank variable
Updated 6.3.3.6 logic and ability to use variable with populated details