### PR TITLE
UMASK regex replacement should require existence of a number affix

### DIFF
--- a/tasks/section_5/cis_5.4.3.x.yml
+++ b/tasks/section_5/cis_5.4.3.x.yml
@@ -52,7 +52,7 @@
     - NIST800-53R5_MP-2
   ansible.builtin.replace:
     path: "{{ item.path }}"
-    regexp: (?i)(umask\s+\d*)
+    regexp: (?i)(umask\s+\d+)
     replace: '{{ item.line }} {{ deb12cis_bash_umask }}'
   loop:
     - { path: '/etc/profile', line: 'umask' }


### PR DESCRIPTION
In the current code, ansible is replacing ALL instances of "UMASK " (even in comments mentioning the string umask) rather than just a fully defined UMASK param. Thus, this will require a string that matches umask + an integer, rather than just umask