### PR TITLE
fixes mis-named handler for dconf

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -199,7 +199,7 @@
     name: postfix
     state: restarted
 
-- name: Reload dconf
+- name: Update dconf
   ansible.builtin.command: dconf update
   changed_when: true
 

--- a/tasks/section_1/cis_1.7.x.yml
+++ b/tasks/section_1/cis_1.7.x.yml
@@ -50,7 +50,7 @@
         create: true
         owner: root
         group: root
-        mode: 'u-x,gw-wx'
+        mode: 'u-x,go-wx'
       loop:
         - { regexp: '\[org\/gnome\/login-screen\]', line: '[org/gnome/login-screen]', insertafter: EOF }
         - { regexp: 'banner-message-enable', line: 'banner-message-enable=true', insertafter: '\[org\/gnome\/login-screen\]'}


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
renamed handler to match the usage of it and fix typo of file perms in GDM section

**Issue Fixes:**
dconf update will work now.

**Enhancements:**
none

**How has this been tested?:**
tested locally
