### PR TITLE
fixes rsync name and systemd handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -227,7 +227,7 @@
     name: systemd-journal-upload
     state: restarted
 
-- name: Systemd daemon reload
+- name: Systemd_daemon_reload
   ansible.builtin.systemd:
     daemon-reload: true
 

--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -415,7 +415,7 @@
         - deb12cis_rsync_mask
       notify: Systemd_daemon_reload
       ansible.builtin.systemd:
-        name: rsyncd.service
+        name: rsync.service
         enabled: false
         state: stopped
         masked: true


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
systemd reload handler was set to a name that doesn't exist

**Issue Fixes:**
systemd reload notify works after normalizing the name

**Enhancements:**
bug fix

**How has this been tested?:**
tested locally
