### PR TITLE
ansible_vars_goss.yml : fix deb12cis_time_pool

### DIFF
--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -526,7 +526,7 @@ deb12cis_time_sync_tool: {{ deb12cis_time_sync_tool }}
 # Each list item contains two settings, `name` (the domain name of the pool) and synchronization `options`.
 # The default setting for the `options` is `iburst maxsources 4` -- please refer to the documentation
 # of the time synchronization mechanism you are using.
-deb12cis_time_pool_name:
+deb12cis_time_pool:
 {% for pool in deb12cis_time_pool %}
   - name: {{ pool.name }}
     options: {{ pool.options }}


### PR DESCRIPTION
it's deb12cis_time_pool , not deb12cis_time_pool_name

Error: could not read json data in /opt/DEBIAN12-CIS-Audit/section_2/cis_2.3/cis_2.3.3.1.yml:
template: test:12:19: executing "test" at <.Vars.deb12cis_time_pool>: map has no entry for key "deb12cis_time_pool"



