### PR TITLE
fix 1.1.1.7 squashfs never blacklisted

### DIFF
--- a/tasks/section_1/cis_1.1.1.x.yml
+++ b/tasks/section_1/cis_1.1.1.x.yml
@@ -195,7 +195,7 @@
 - name: "1.1.1.7 | PATCH | Ensure squashfs kernel module is not available"
   when:
     - deb12cis_rule_1_1_1_7
-    - not prelim_squashfs_builtin
+    - prelim_squashfs_builtin.rc != 0
     - prelim_snap_pkg_mgr.rc != 0
   tags:
     - level2-server


### PR DESCRIPTION
prelim_squashfs_builtin is checked with "cat /lib/modules/$(uname -r)/modules.builtin | grep -c "squashfs", and return code is 1 when not found

We need to check the return code, as the variable is always registered with 1 or 0.


