### PR TITLE
fix: Bad permission for rule 7.1.5

### DIFF
--- a/tasks/section_7/cis_7.1.x.yml
+++ b/tasks/section_7/cis_7.1.x.yml
@@ -78,7 +78,7 @@
     path: /etc/shadow
     owner: root
     group: root
-    mode: 'ugo-rwx'
+    mode: 'u-x,g-wx,o-rwx'
 
 - name: "7.1.6 | PATCH | Ensure permissions on /etc/shadow- are configured"
   when: deb12cis_rule_7_1_6
@@ -94,7 +94,7 @@
     path: /etc/shadow-
     owner: root
     group: root
-    mode: 'ugo-rwx'
+    mode: 'u-x,g-wx,o-rwx'
 
 - name: "7.1.7 | PATCH | Ensure permissions on /etc/gshadow are configured"
   when: deb12cis_rule_7_1_7


### PR DESCRIPTION
In CIS PDF:

> chmod u-x,g-wx,o-rwx /etc/shadow

Double checked with Tenable:

https://www.tenable.com/audits/items/CIS_Debian_Linux_12_v1.1.0_L1_Server.audit:786dace5f23f1091ff0aac9e4ed2f6d5
