### PR TITLE
fix: No changes are made for rule 5.4.3.3

### DIFF
--- a/tasks/section_5/cis_5.4.3.x.yml
+++ b/tasks/section_5/cis_5.4.3.x.yml
@@ -50,10 +50,9 @@
     - rule_5.4.3.3
     - NIST800-53R5_AC-3
     - NIST800-53R5_MP-2
-  ansible.builtin.replace:
-    path: "{{ item.path }}"
-    regexp: (?i)(umask\s+\d+)
-    replace: '{{ item.line }} {{ deb12cis_bash_umask }}'
-  loop:
-    - { path: '/etc/profile', line: 'umask' }
-    - { path: '/etc/login.defs', line: 'UMASK' }
+  ansible.builtin.template:
+    src: etc/profile.d/CIS.sh.j2
+    dest: /etc/profile.d/CIS.sh
+    mode: u=rw,g=r,o=r
+    owner: root
+    group: root

--- a/templates/etc/profile.d/CIS.sh.j2
+++ b/templates/etc/profile.d/CIS.sh.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+umask {{ deb12cis_bash_umask }}


### PR DESCRIPTION
Using precedence like CIS PDF:

> Order of precedence:
> 1. A file in /etc/profile.d/ ending in .sh - This will override any other system-wide umask setting
> 2. In the file /etc/profile
> 3. On the pam_umask.so module in /etc/pam.d/postlogin
> 4. In the file /etc/login.defs
> 5. In the file /etc/default/login

Double checked with Tenable:

https://www.tenable.com/audits/items/CIS_Debian_Linux_12_v1.1.0_L1_Server.audit:dfea0f696a31d4d5fe2c9364c724d131

