### PR TITLE
fix: tmp.mount restart fails for rules 1.1.2.5.{2,3,4}

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -22,6 +22,8 @@
   listen: "Remount /tmp"
 
 - name: "Remounting /tmp systemd"
+  when: deb12cis_tmp_svc
+  ignore_errors: true
   vars:
     mount_point: '/tmp'
   ansible.builtin.systemd:


### PR DESCRIPTION
I reproduce the following problem each time:

```
RUNNING HANDLER [DEBIAN12-CIS : Remounting /tmp] *******************************
changed: [127.0.0.1]

RUNNING HANDLER [DEBIAN12-CIS : Remounting /tmp systemd] ***********************
[ERROR]: Task failed: Module failed: Unable to restart service tmp.mount: Job failed. See "journalctl -xe" for details.

Origin: /home/ansible/galaxy_roles/DEBIAN12-CIS/handlers/main.yml:24:3

22   listen: "Remount /tmp"
23
24 - name: "Remounting /tmp systemd"
     ^ column 3

fatal: [127.0.0.1]: FAILED! =>
    changed: false
    msg: |-
        Unable to restart service tmp.mount: Job failed. See "journalctl -xe" for details.
```

