### PR TITLE
fix: prelim 5.4.2.4 check for locked root password

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,7 +95,7 @@
     - rule_5.4.2.4
   block:
     - name: "Ensure root password is set"
-      ansible.builtin.shell: passwd -S root | grep 'root P'
+      ansible.builtin.shell: LC_ALL=C passwd -S root | grep -E "(Password set, SHA512 crypt|root P |root L |Password locked)"
       changed_when: false
       failed_when: false
       register: prelim_check_root_passwd_set


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Change the way to check that a root password is set. A locked root password should be accepted as well. 
This is the same command that is used for the same check for [UBUNTU24-CIS](https://github.com/ansible-lockdown/UBUNTU24-CIS/blob/devel/tasks/main.yml#L47).

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

**Enhancements:**
The root user can be password can be locked and no actual password needs to be set.

**How has this been tested?:**
Manual

