### PR TITLE
fix: do not create /nonexistent homedirs

### DIFF
--- a/tasks/section_5/cis_5.4.2.x.yml
+++ b/tasks/section_5/cis_5.4.2.x.yml
@@ -212,6 +212,7 @@
   ansible.builtin.user:
     name: "{{ item.id }}"
     shell: /usr/sbin/nologin
+    create_home: false
   loop: "{{ prelim_captured_passwd_data }}"
   loop_control:
     label: "{{ item.id }}"


### PR DESCRIPTION
Multiple users have /nonexistent as homedir by Debian packaging guideline

The task "5.4.2.7 | PATCH | Ensure system accounts do not have a valid login
shell" is creating the folder because ansible.builtin.user default to create the
missing homedir, which is unexpected, as /nonexitent is not meant to be created.

This commit avoids this unexpected behavior.