### PR TITLE
fix tmp mount handlers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,6 +14,7 @@
   listen: "Remount /tmp"
 
 - name: "Remounting /tmp"
+  when: deb12cis_tmp_svc is falsy
   vars:
     mount_point: '/tmp'
   ansible.posix.mount:
@@ -22,11 +23,10 @@
   listen: "Remount /tmp"
 
 - name: "Remounting /tmp systemd"
-  vars:
-    mount_point: '/tmp'
+  when: deb12cis_tmp_svc is truthy
   ansible.builtin.systemd:
     name: tmp.mount
-    state: restarted
+    state: reloaded
     daemon_reload: true
   listen: "Remount /tmp"
 


### PR DESCRIPTION
deb12cis_tmp_svc should be checked on both handlers or both handlers would be
run.

The correct way to remount an mount unit is to use reloaded. Restarted would
only work if the mount unit was not yet started and fails otherwise as the
target would be busy. Also reloaded ensure the unit is started.

Signed-off-by: seven beep <ebn@entreparentheses.xyz>